### PR TITLE
Always use qmake to build breakpad

### DIFF
--- a/src/3rdparty/breakpad/breakpad-config.pri
+++ b/src/3rdparty/breakpad/breakpad-config.pri
@@ -20,10 +20,4 @@ android {
 isEmpty(BREAKPAD_BUILDDIR): BREAKPAD_BUILDDIR = $$shadowed($$PWD/build-target)
 isEmpty(BREAKPAD_HOSTDIR): BREAKPAD_HOSTDIR = $$BREAKPAD_BUILDDIR
 
-android {
-    BREAKPAD_LIBRARY = $$system_path($$BREAKPAD_BUILDDIR/libbreakpad_client.a)
-} else: linux {
-    BREAKPAD_LIBRARY = $$system_path($$BREAKPAD_BUILDDIR/src/client/linux/libbreakpad_client.a)
-} else: ios: CONFIG(device, device|simulator) {
-    BREAKPAD_LIBRARY = $$shadowed($$PWD/libbreakpad.a)
-}
+BREAKPAD_LIBRARY = $$shadowed($$PWD/libbreakpad.a)

--- a/src/3rdparty/breakpad/breakpad_dummy.cpp
+++ b/src/3rdparty/breakpad/breakpad_dummy.cpp
@@ -1,1 +1,3 @@
-int main() { return 0; } // move on, nothing to see
+// XCode doesn't accept empty static libraries without object files, or symbols.
+// So let's define a dummy function to make it happy.
+void breakpad_dummy() {}


### PR DESCRIPTION
Just like for iOS this ensures consistent compiler flags. Additionally
this works around include problems from long file paths on Windows when
running CI on Windows.