### PR TITLE
Include <io.h> instead of <unistd.h> for MSVC

### DIFF
--- a/src/KDHockeyApp/KDHockeyAppManager.cpp
+++ b/src/KDHockeyApp/KDHockeyAppManager.cpp
@@ -44,7 +44,12 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+
+#ifdef Q_CC_MSVC
+#include <io.h>
+#else
 #include <unistd.h>
+#endif
 
 extern "C" Q_QML_EXPORT char *qt_v4StackTrace(void *);
 


### PR DESCRIPTION
There simply is no unistd.h with Visual C++.