### PR TITLE
Fix minimum platform version check

### DIFF
--- a/src/KDHockeyApp/KDHockeyAppManager.cpp
+++ b/src/KDHockeyApp/KDHockeyAppManager.cpp
@@ -294,7 +294,7 @@ HockeyAppManager::AppInfo HockeyAppManager::Private::makeAppInfo()
     fillAppInfo(&appInfo);
 
     if (appInfo.platformVersion.isEmpty())
-        appInfo.platformVersion = QSysInfo::productType() + ' '_l1 + QSysInfo::productVersion();
+        appInfo.platformVersion = QSysInfo::productVersion();
     if (appInfo.platformBuild.isEmpty())
         appInfo.platformBuild = QSysInfo::kernelType() + ' '_l1 + QSysInfo::kernelVersion();
     if (appInfo.packageName.isEmpty())


### PR DESCRIPTION
This code lead to "ios 11.4" on my iPad. The platformVersion is used
with QVersionNumber to compare to the minimum platform version of new
app versions, and QVersionNumber fails to parse "ios 11.4".
The platform type is also available already as "platformId", so I think
the version should just be omitted here.

Fixes #12